### PR TITLE
enforcing valid templates for manually added programs

### DIFF
--- a/src/contracts/AludelFactory.sol
+++ b/src/contracts/AludelFactory.sol
@@ -75,7 +75,6 @@ contract AludelFactory is Ownable {
         public
         returns (address aludel)
     {
-        // reverts when template address is not registered
         if (!_templates[template].listed) {
             revert TemplateNotRegistered();
         }
@@ -205,8 +204,8 @@ contract AludelFactory is Ownable {
         if(isAludel(program)){
           revert AludelAlreadyRegistered();
         }
-        if (template == address(0)) {
-            revert InvalidTemplate();
+        if (!_templates[template].listed) {
+            revert TemplateNotRegistered();
         }
 
         // add program's data to the storage


### PR DESCRIPTION
they don't have to be enabled, though.

I also changed the error when sending template zero to TemplateNotRegistered since there was no point in having the two checks