### PR TITLE
use deployer signer in deployments scripts

### DIFF
--- a/deploy/AludelV1Template.ts
+++ b/deploy/AludelV1Template.ts
@@ -10,7 +10,7 @@ const deployFunc = async function ({
 }: HardhatRuntimeEnvironment) {
   const { get, log } = deployments;
 
-  const { deployer } = await getNamedAccounts()
+  const { deployer } = await getNamedAccounts();
   const deployedFactory = await get("AludelFactory");
   const factory = await ethers.getContractAt(
     deployedFactory.abi,

--- a/deploy/AludelV1Template.ts
+++ b/deploy/AludelV1Template.ts
@@ -1,4 +1,5 @@
 import "@nomiclabs/hardhat-ethers";
+import { getNamedAccounts } from "hardhat";
 import "hardhat-deploy";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { ALUDEL_V1_VANITY_ADDRESS } from "../constants";
@@ -9,10 +10,12 @@ const deployFunc = async function ({
 }: HardhatRuntimeEnvironment) {
   const { get, log } = deployments;
 
+  const { deployer } = await getNamedAccounts()
   const deployedFactory = await get("AludelFactory");
   const factory = await ethers.getContractAt(
     deployedFactory.abi,
-    deployedFactory.address
+    deployedFactory.address,
+    await ethers.getSigner(deployer)
   );
 
   log("Adding disabled AludelV1 empty template to factory");

--- a/deploy/AludelV2Template.ts
+++ b/deploy/AludelV2Template.ts
@@ -1,4 +1,5 @@
 import "@nomiclabs/hardhat-ethers";
+import { getNamedAccounts } from "hardhat";
 import "hardhat-deploy";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
@@ -9,11 +10,13 @@ const deployFunc = async function ({
   const { get, log } = deployments;
 
   const aludelContract = await get("AludelV2");
-
+  const { deployer } = await getNamedAccounts()
   const deployedFactory = await get("AludelFactory");
   const factory = await ethers.getContractAt(
     deployedFactory.abi,
-    deployedFactory.address
+    deployedFactory.address,
+    await ethers.getSigner(deployer)
+
   );
 
   log("Adding working AludelV2 templates to factory");

--- a/deploy/AludelV2Template.ts
+++ b/deploy/AludelV2Template.ts
@@ -10,13 +10,12 @@ const deployFunc = async function ({
   const { get, log } = deployments;
 
   const aludelContract = await get("AludelV2");
-  const { deployer } = await getNamedAccounts()
+  const { deployer } = await getNamedAccounts();
   const deployedFactory = await get("AludelFactory");
   const factory = await ethers.getContractAt(
     deployedFactory.abi,
     deployedFactory.address,
     await ethers.getSigner(deployer)
-
   );
 
   log("Adding working AludelV2 templates to factory");

--- a/deploy/GeyserV2Template.ts
+++ b/deploy/GeyserV2Template.ts
@@ -10,7 +10,7 @@ const deployFunc = async function ({
 }: HardhatRuntimeEnvironment) {
   const { get, log } = deployments;
 
-  const { deployer } = await getNamedAccounts()
+  const { deployer } = await getNamedAccounts();
   const deployedFactory = await get("AludelFactory");
   const factory = await ethers.getContractAt(
     deployedFactory.abi,

--- a/deploy/GeyserV2Template.ts
+++ b/deploy/GeyserV2Template.ts
@@ -1,4 +1,5 @@
 import "@nomiclabs/hardhat-ethers";
+import { getNamedAccounts } from "hardhat";
 import "hardhat-deploy";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { GEYSER_V2_VANITY_ADDRESS } from "../constants";
@@ -9,11 +10,14 @@ const deployFunc = async function ({
 }: HardhatRuntimeEnvironment) {
   const { get, log } = deployments;
 
+  const { deployer } = await getNamedAccounts()
   const deployedFactory = await get("AludelFactory");
   const factory = await ethers.getContractAt(
     deployedFactory.abi,
-    deployedFactory.address
+    deployedFactory.address,
+    await ethers.getSigner(deployer)
   );
+
   log("Adding disabled GeyserV2 empty template to factory");
   // this is only meant to add previous programs, therefore it's disabled from the start
   try {


### PR DESCRIPTION
hardhat defaults to index 0 account when no signer is specified, which breaks local changes in the hardhat config.