### PR TITLE
fix on TimelockHook test 

### DIFF
--- a/src/test/TimelockHook.t.sol
+++ b/src/test/TimelockHook.t.sol
@@ -10,12 +10,13 @@ import "forge-std/console2.sol";
 contract PowerSwitchTest is Test {
 
     function test_n_days(uint8 n) public {
+        vm.assume(n > 0);
         uint256 lockTime = uint256(n) * 1 days;
-        IAludelV3.StakeData memory stake = IAludelV3.StakeData({amount: 100, timestamp: 1});
+        IAludelV3.StakeData memory stake = IAludelV3.StakeData({amount: 100, timestamp: block.timestamp});
         TimelockHook hook = new TimelockHook(lockTime);
         vm.expectRevert(TimelockHook.TimelockNotElapsed.selector);
         hook.unstakeAndClaimPost(stake);
-        vm.warp(lockTime + 2);
+        vm.warp(block.timestamp + lockTime + 2);
         hook.unstakeAndClaimPost(stake);
     }
 }


### PR DESCRIPTION
i think there was an update in anvil and now it sets as the initial timestamp the local unix timestamp instead of `1` as it did previously

so now it uses block.timestamp to make the test time agnostic

Merge after #43